### PR TITLE
feat: change synchronizer return types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemaskinc/store",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "- ⚛️ updates outside react components - 🪝 easy access to all store values - ✍️ no repeating yourself - ⚡️ no unnecessary rerenders - 🚀 typescript intellisense",
   "source": "src/index.ts",
   "main": "./dist/index.js",

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -36,9 +36,9 @@ const ssrSaveStorage = {
     },
 }
 
-export function storage<T>(initialValue: T, localStorageKey?: string): Synchronizer<T>
+export function storage<T>(initialValue: T, localStorageKey?: string): T
 // eslint-disable-next-line no-redeclare
-export function storage<T>(initialValue?: T, localStorageKey?: string): Synchronizer<T | undefined>
+export function storage<T>(initialValue?: T, localStorageKey?: string): T | undefined
 // eslint-disable-next-line no-redeclare, prefer-arrow/prefer-arrow-functions
 export function storage<T>(initialValue: T, localStorageKey?: string) {
     return {

--- a/src/tests/storage.test.ts
+++ b/src/tests/storage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, spyOn } from 'bun:test'
 import { isLocalStorageAvailable, storage } from '../storage'
+import { Synchronizer } from '../types'
 
 describe('isLocalStorageAvailable', () => {
     const windowStub = spyOn(window, 'window')
@@ -23,7 +24,7 @@ describe('storage', () => {
     })
 
     it('should update value', () => {
-        const { update, getSnapshot } = storage(1, 'key')
+        const { update, getSnapshot } = storage(1, 'key') as unknown as Synchronizer<number>
 
         update(2, 'key')
 


### PR DESCRIPTION
Previously you couldn't do something like that:

```ts
import { createStore, storage } from '@codemaskinc/store'

export type Settings = {
	theme: {
		colorScheme: 'dark' | 'light' | undefined
		dynamicColor: boolean
		disabledAnimations: boolean
	}
	language?: string
}

export const settingsStore = createStore<Settings>({
	theme: storage({
		colorScheme: undefined,
		dynamicColor: true,
		disabledAnimations: false,
	}),
	language: storage(undefined),
})
```

It will throw type error for a simple reason - type A doesn't match with type Synchronizer<A>

You would need to do this that way:
```ts
import { createStore, storage } from '@codemaskinc/store'

export type Settings = {
	theme: {
		colorScheme: 'dark' | 'light' | undefined
		dynamicColor: boolean
		disabledAnimations: boolean
	}
	language?: string
}

export const settingsStore = createStore({
	theme: storage<Settings['theme']>({
		colorScheme: undefined,
		dynamicColor: true,
		disabledAnimations: false,
	}),
	language: storage<Settings['language']>(undefined),
})
```

We can lie about storage util type, and have overall better DX
